### PR TITLE
Fix title casing: biosimulations-runutils → BioSimulations runutils

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "upload_type": "software",
-  "title": "biosimulations-runutils",
+  "title": "BioSimulations runutils",
   "license": "mit",
   "creators": [
     {

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it using these metadata."
-title: "biosimulations-runutils"
+title: "BioSimulations runutils"
 type: software
 repository-code: "https://github.com/biosimulations/biosimulations-runutils"
 license: MIT


### PR DESCRIPTION
Aligns the `.zenodo.json` and `CITATION.cff` titles with the published Zenodo record, which displays **BioSimulations runutils** — both files carried the lowercased repo name `biosimulations-runutils`.

Because release archiving uses `.zenodo.json` verbatim, the next release would have **regressed** the published title. Updating both files keeps them consistent and prevents a `cffconvert` regen from reintroducing the lowercase form.

Surfaced by `zenodo-maint audit`.

> Base branch is `dev` (this repo's default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZx7w9BexQc9wWU5JoHYaF